### PR TITLE
Fix: HTML symbols in title isn't properly rendered

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -11,7 +11,9 @@
     </title>
     {% else %}
     <title>
-        {{ page.title | default(value=config.title) | default(value="Post") }}
+        {% if page.title %} {{ page.title }}
+        {% elif config.title %} {{ config.title }}
+        {% else %}Post{% endif %}
     </title>
     {% endif %}
 


### PR DESCRIPTION
HTML symbols in title is not rendered. It looks like: 
![image](https://user-images.githubusercontent.com/16359093/189575287-5200ac28-0868-4e84-8804-7d2f9e8fae75.png)
while it's suppose to be: 
![image](https://user-images.githubusercontent.com/16359093/189575238-5622ef44-9956-4095-9d81-0d607efedc6a.png)
Probably due to limitation in Tera. Here is a [related issue](https://github.com/Keats/tera/issues/615). It can easily be fixed by replacing default() with if-else(Don't know the reason behind this). 