### PR TITLE
Add meta tag support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ theme = "archie-zola"
 * Auto Dark Mode(based on system theme)
 * Dark/Light Mode toggle
 * Google Analytics Script
-* Meta tags for individual pages
+* Meta Tags For Individual Pages
 
 in the planning stage：
 
@@ -55,35 +55,42 @@ in the planning stage：
 
 ### Customize `<meta/>` tags 
 
-The following TOML and YAML code will yiled two `<meta/>` tags, `<meta property="og:title" content="this is a title" />`, `<meta property="og:description" content="this is a description" />`. 
+The following TOML and YAML code will yiled two `<meta/>` tags, `<meta property="og:title" content="the og title"/>`, `<meta property="og:description" content="the og description"/>`. 
 
 TOML: 
 
 ```toml
-title = "hello world"
-description = "hello world"
+title = "post title"
+description = "post desc"
 date = "2023-01-01"
+
 [extra]
-    [[meta]]
-    property = "og:title"
-    content = "this is title "
-    [[meta]]
-    property = "og:description"
-    content = "this is description"
+meta = [
+    {property = "og:title", content = "the og title"},
+    {property = "og:description", content = "the og description"},
+]
 ```
 
 YAML: 
 
 ```yaml
-title: "hello world"
-description: "hello ya"
+title: "post title"
+description: "post desc"
 date: "2023-01-01"
 extra: 
     meta: 
         - property: "og:title"
-          content: "this is title "
+          content: "the og title"
         - property: "og:description"
-          content: "this is description"
+          content: "the og description"
+```
+
+If the `og:title` and the `og:description` are not set, the page's title and description will be used. That is, the following TOML code generates `<meta property="og:title" content="post title"/>` and `<meta property="og:description" content="post desc"/>`. 
+
+```toml
+title = "post title"
+description = "post desc"
+date = "2023-01-01"
 ```
 
 ### Theme config

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ extra:
           content: "the og description"
 ```
 
-If the `og:title` and the `og:description` are not set, the page's title and description will be used. That is, the following TOML code generates `<meta property="og:title" content="post title"/>` and `<meta property="og:description" content="post desc"/>`. 
+If the `og:title`, the `og:description`, or the "description" are not set, the page's title and description will be used. That is, the following TOML code generates `<meta property="og:title" content="post title"/>`, `<meta property="og:description" content="post desc"/>`, and `<meta property="og:description" content="post desc"/>` as default values. 
 
 ```toml
 title = "post title"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ theme = "archie-zola"
 * Auto Dark Mode(based on system theme)
 * Dark/Light Mode toggle
 * Google Analytics Script
+* Meta tags for individual pages
 
 in the planning stage：
 
@@ -52,6 +53,38 @@ in the planning stage：
 
 ## Config
 
+### Customize `<meta/>` tags 
+
+The following TOML and YAML code will yiled two `<meta/>` tags, `<meta property="og:title" content="this is a title" />`, `<meta property="og:description" content="this is a description" />`. 
+
+TOML: 
+
+```toml
+title = "hello world"
+description = "hello world"
+date = "2023-01-01"
+[extra]
+    [[meta]]
+    property = "og:title"
+    content = "this is title "
+    [[meta]]
+    property = "og:description"
+    content = "this is description"
+```
+
+YAML: 
+
+```yaml
+title: "hello world"
+description: "hello ya"
+date: "2023-01-01"
+extra: 
+    meta: 
+        - property: "og:title"
+          content: "this is title "
+        - property: "og:description"
+          content: "this is description"
+```
 
 ### Theme config
 

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -13,7 +13,10 @@
                         {% set_global page_has_og_title = true -%}
                     {% endif %}
                     {% if key == "property" and value == "og:description"%}
-                        {% set_global page_has_og_desc = true -%}
+                        {% set_global page_has_og_description = true -%}
+                    {% endif %}
+                    {% if key == "name" and value == "description"%}
+                        {% set_global page_has_description = true -%}
                     {% endif %}
                     {{ key }}="{{ value }}"
                 {% endfor %}
@@ -45,6 +48,14 @@
             <meta property="og:description" content="{{ page.description }}" />
         {% elif config.description %}
             <meta property="og:description" content="{{ config.description }}" />
+        {% endif %}
+    {% endif %}
+
+    {% if not page_has_description %}
+        {% if page.description %}
+            <meta name="description" content="{{ page.description }}" />
+        {% elif config.description %}
+            <meta name="description" content="{{ config.description }}" />
         {% endif %}
     {% endif %}
 

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -4,31 +4,49 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    {% if current_path == "/" %}
-    <title>
-        {{ config.title | default(value="Home") }}
-    </title>
-    {% else %}
-    <title>
-        {% if page.title %} {{ page.title }}
-        {% elif config.title %} {{ config.title }}
-        {% else %}Post{% endif %}
-    </title>
-    {% endif %}
-
     {% if page.extra.meta %}
         <!-- the meta data config goes here  -->
         {% for data in page.extra.meta %}
             <meta 
                 {% for key, value in data%}
+                    {% if key == "property" and value == "og:title"%}
+                        {% set_global page_has_og_title = true -%}
+                    {% endif %}
+                    {% if key == "property" and value == "og:description"%}
+                        {% set_global page_has_og_desc = true -%}
+                    {% endif %}
                     {{ key }}="{{ value }}"
                 {% endfor %}
             />
         {% endfor %}
     {% endif %}
 
-    
+    {% if current_path == "/" %}
+        <title>
+            {{ config.title | default(value="Home") }}
+        </title>
+        {% if not page_has_og_title %}
+            <meta property="og:title" content="{{ config.title | default(value="Home") }}" />
+        {% endif %}
+    {% else %}
+        <title>
+            {% if page.title %} {{ page.title }}
+            {% elif config.title %} {{ config.title }}
+            {% else %} Post {% endif %}
+        </title>
+
+        {% if not page_has_og_title %}
+            <meta property="og:title" content="{% if page.title -%}{{ page.title }}{% elif config.title -%}{{ config.title }}{% else -%}Post{% endif -%}" />
+        {% endif %}
+    {% endif %}
+
+    {% if not page_has_og_description %}
+        {% if page.description %}
+            <meta property="og:description" content="{{ page.description }}" />
+        {% elif config.description %}
+            <meta property="og:description" content="{{ config.description }}" />
+        {% endif %}
+    {% endif %}
 
     {% if config.extra.favicon %}
          <link rel="icon" type="image/png" href={{ config.extra.favicon }} />

--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -17,11 +17,22 @@
     </title>
     {% endif %}
 
+    {% if page.extra.meta %}
+        <!-- the meta data config goes here  -->
+        {% for data in page.extra.meta %}
+            <meta 
+                {% for key, value in data%}
+                    {{ key }}="{{ value }}"
+                {% endfor %}
+            />
+        {% endfor %}
+    {% endif %}
+
+    
+
     {% if config.extra.favicon %}
          <link rel="icon" type="image/png" href={{ config.extra.favicon }} />
     {% endif %}
-
-    {# TODO: rss, og:image #}
 
     {# opengraph, twitter_cards #}
 


### PR DESCRIPTION
- add meta tag support for individual pages 
  ```yaml
  ...
  extra:
    meta: 
      - property: og:title 
        content: the title of the page 
      - property: og:description
        content: the description of the page 
  ```
  The YAML code above will generate `<meta property="og:title" content="the title of the page"/>` and `<meta property="og:description" content="the description of the page"/>`. 
- default the `og:title` and `og:description` to the pages' title and description. 