### PR TITLE
fix: wrong posts list generated in multilingual site

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
             {%- if paginator %}
                 {%- set show_pages = paginator.pages -%}
             {% else %}
-                {% set section = get_section(path="posts/_index.md") %}
+                {% set section = get_section(path="posts/_index.md", lang=lang) %}
                 {%- set show_pages = section.pages -%}
             {% endif -%}
 

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -1,6 +1,6 @@
 {% extends "index.html" %}
 
 {% block main_content %}
-    {% set section = get_section(path="posts/_index.md") %}
+    {% set section = get_section(path="posts/_index.md", lang=lang) %}
     {{ post_macros::list_title(pages=section.pages) }}
 {% endblock main_content %}


### PR DESCRIPTION
The get_section() function includes a lang parameter as of this [PR](https://github.com/getzola/zola/pull/2410). This update is essential for multilingual sites; without it, only articles in the default language will be displayed, even if the user switches languages.