### PR TITLE
Starting intro at `opacity: 0.01` for Lighthouse support

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -25,7 +25,7 @@ body {
 
 @keyframes intro {
   0% {
-    opacity: 0;
+    opacity: 0.01;
   }
 
   100% {


### PR DESCRIPTION
Before: the intro animation starts at `opacity: 0` which throws Lighthouse off and raises a NO_FCP error.

<img width="1266" height="645" alt="lighthouse_error" src="https://github.com/user-attachments/assets/40892563-48c6-4741-ae25-ceb924ef7e3a" />


After setting the intro to start at `opacity: 0.01` , Lighthouse analysis works correctly.

<img width="1270" height="647" alt="lighthouse_fixed" src="https://github.com/user-attachments/assets/af44fef3-041a-4e1f-a260-16a41e2edfb2" />
