### PR TITLE
Bugfix: Remove unsafe characters from summaries

### DIFF
--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -37,7 +37,7 @@
             <div class="description">
                 {% if page.description %}
                     {{ page.description }}
-                {% elif page.summary %}
+                {% elif page.summary | safe %}
                     {{ page.summary }}&hellip;
                 {% else %}
                     {% set hide_read_more = true %}


### PR DESCRIPTION
Hi!
When building a website that uses this theme and zola v0.22.1, it looks like post summaries now contain raw html inside the `<div class='description'>` container. This didn't happen in zola v0.17, which is what I last used before noticing the bug, so maybe it's due to some other changes upstream.

But basically, things would look like this:
<img width="1056" height="593" alt="before" src="https://github.com/user-attachments/assets/a1cf6a8a-5fd3-4ce5-a826-1a844ce93650" />

Potentially a "good" fix would be more involved, but even the official docs use this `page.summary | safe` approach, so maybe that's fine? Let me know what you think.

For reference:
- Official example on how to show summaries: https://www.getzola.org/documentation/templates/pagination/#example
  - Related source code: https://github.com/getzola/zola/blob/7ea116a353a0c7483dd3b3205fcbe259a68468e4/docs/content/documentation/templates/pagination.md?plain=1#L71
- Current impl of the 'safe' keyword: https://github.com/getzola/zola/blob/7ea116a353a0c7483dd3b3205fcbe259a68468e4/components/utils/src/slugs.rs#L23
- Tera's docs on `safe`: https://keats.github.io/tera/docs/#safe

## After this PR

Post summaries are displayed correctly:

<img width="1074" height="1296" alt="after" src="https://github.com/user-attachments/assets/194edd81-b5e2-425b-94ba-19a5f9cc566a" />

The first post shown in the screenshot uses this markdown:

```markdown
+++
title = "Technical bits - Houdini 21.0 Copernicus Ceramic Material Test"
date = 2025-09-20

[taxonomies]
tags = ["3D", "modeling", "procedural", "3D Art", "Houdini", "lookdev", "texture"]
+++

An overview of my workflow for creating a ceramic material from textures generated with Copernicus in Houdini 21.0 (and a bonus procedural ceramic mesh).
<div align="center">
<img src="/images/houdini-ceramics/glaze_ball_ocio_v002.jpg" width="50%" /> 
</div>

<!-- more -->

For a complete view of the project you can check out my  [ArtStation](https://www.artstation.com/artwork/DLJVBn).
[..redacted..]
```